### PR TITLE
Limit view to visited area

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,18 @@ let px = 0, py = 0; // позиция игрока в мире
 let seedX = 73856093, seedY = 19349663; // множители генерации стен
 let exploding = false; // взрыв в процессе
 
+// посещённые области
+const REVEAL_RADIUS = 2;
+const revealed = new Set();
+function revealAround(x, y){
+  for(let dx=-REVEAL_RADIUS; dx<=REVEAL_RADIUS; dx++){
+    for(let dy=-REVEAL_RADIUS; dy<=REVEAL_RADIUS; dy++){
+      revealed.add((x+dx)+","+(y+dy));
+    }
+  }
+}
+revealAround(px, py);
+
 // псевдослучайные стены
 function isWall(x,y){
   if ((x===0 && y===0) || (Math.abs(x)+Math.abs(y)===1)) return false;
@@ -77,14 +89,17 @@ function moveBy(dx, dy){
   if (exploding) return;
   const nx = px + dx, ny = py + dy;
   if (isWall(nx, ny)) return;
-  if (isMine(nx, ny)){
+
+  px = nx; py = ny;
+  revealAround(px, py);
+
+  if (isMine(px, py)){
     exploding = true;
-    px = nx; py = ny;
     render();
     drawExplosion();
-    setTimeout(()=>{ px=0; py=0; exploding=false; render(); }, 500);
+    setTimeout(()=>{ px=0; py=0; revealAround(px,py); exploding=false; render(); }, 500);
   }else{
-    px = nx; py = ny; render();
+    render();
   }
 }
 
@@ -99,25 +114,22 @@ function render(){
   const tlx = px - halfC, tly = py - halfR;
   const brx = tlx + VIEW_COLS - 1, bry = tly + VIEW_ROWS - 1;
 
-  // сетка
-  ctx.strokeStyle = '#ccc';
-  for(let r=0;r<=VIEW_ROWS;r++){
-    const y=r*CELL; ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(canvas.width,y); ctx.stroke();
-  }
-  for(let c=0;c<=VIEW_COLS;c++){
-    const x=c*CELL; ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,canvas.height); ctx.stroke();
-  }
-
-  // стены и мины
+  // видимые клетки
   for(let gy=tly; gy<=bry; gy++){
     for(let gx=tlx; gx<=brx; gx++){
-      const sx=(gx-tlx)*CELL+1, sy=(gy-tly)*CELL+1;
+      const key=gx+","+gy;
+      if(!revealed.has(key)) continue;
+      const sx=(gx-tlx)*CELL, sy=(gy-tly)*CELL;
+
+      ctx.strokeStyle='#ccc';
+      ctx.strokeRect(sx,sy,CELL,CELL);
+
       if (isWall(gx,gy)){
         ctx.fillStyle='#777';
-        ctx.fillRect(sx,sy,CELL-2,CELL-2);
+        ctx.fillRect(sx+1,sy+1,CELL-2,CELL-2);
       }else if(isMine(gx,gy)){
         ctx.fillStyle='#f00';
-        ctx.fillRect(sx,sy,CELL-2,CELL-2);
+        ctx.fillRect(sx+1,sy+1,CELL-2,CELL-2);
       }
     }
   }


### PR DESCRIPTION
## Summary
- track visited tiles and reveal a small radius around the player
- render only revealed cells, hiding unexplored areas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab350bea5483299142c8e845c34386