### PR TITLE
Show nearby mine count on player

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,9 +161,13 @@ function render(){
     ctx.fillStyle = '#3572ff';
     const psx=(px-tlx)*CELL+1, psy=(py-tly)*CELL+1;
     ctx.fillRect(psx,psy,CELL-2,CELL-2);
+    const playerMines=countAdjacentMines(px,py);
+    ctx.fillStyle='#fff';
+    ctx.fillText(playerMines, psx+CELL/2, psy+CELL/2);
   }
 
-  coordEl.textContent = `x: ${px}, y: ${py}`;
+  const currentMines = countAdjacentMines(px,py);
+  coordEl.textContent = `x: ${px}, y: ${py}, mines: ${currentMines}`;
 }
 render();
 


### PR DESCRIPTION
## Summary
- Display number of nearby mines on the player's tile and in the coordinate readout.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3edf03008329a8688fdbb3c8e042