### PR TITLE
feat: add dark theme and highlight visited cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no" />
 <title>Grid Game Mobile</title>
 <style>
-  html,body{margin:0;height:100%;background:#eee;font-family:system-ui,Arial}
+  html,body{margin:0;height:100%;background:#333;font-family:system-ui,Arial}
   #wrap{display:flex;flex-direction:column;height:100%}
-  canvas{touch-action:none;display:block;margin:0 auto;background:#eee;border:1px solid #999}
+  canvas{touch-action:none;display:block;margin:0 auto;background:#333;border:1px solid #999}
   #coords{text-align:center;margin-top:4px;font-size:14px}
   #seeds{text-align:center;margin-top:4px;font-size:14px}
   #seeds input{width:90px}
@@ -153,7 +153,9 @@ function render(){
       if(!revealed.has(key)) continue;
       const sx=(gx-tlx)*CELL, sy=(gy-tly)*CELL;
 
-      ctx.strokeStyle='#ccc';
+      ctx.fillStyle='#555';
+      ctx.fillRect(sx,sy,CELL,CELL);
+      ctx.strokeStyle='#444';
       ctx.strokeRect(sx,sy,CELL,CELL);
 
       if (isWall(gx,gy)){


### PR DESCRIPTION
## Summary
- use dark gray background for page and play field
- highlight explored cells with lighter gray

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ab43c7f3f88329b9c8eac080c42a79