### PR TITLE
Change player display in defuse mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,11 +180,11 @@ function render(){
 
   // игрок (в центре экрана)
   if(!exploding){
-    ctx.fillStyle = '#3572ff';
     const psx=(px-tlx)*CELL+1, psy=(py-tly)*CELL+1;
+    ctx.fillStyle = defuseMode ? '#ff0' : '#3572ff';
     ctx.fillRect(psx,psy,CELL-2,CELL-2);
     const playerMines=countAdjacentMines(px,py);
-    ctx.fillStyle='#fff';
+    ctx.fillStyle=defuseMode ? '#000' : '#fff';
     ctx.fillText(playerMines, psx+CELL/2, psy+CELL/2);
   }
 


### PR DESCRIPTION
## Summary
- Visualize defuse mode by drawing the player in yellow instead of blue
- Switch mine count overlay to black when defusing for better contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4cf5e9408329877213ff9b34361a