### PR TITLE
Prevent player from stepping onto flagged mines

### DIFF
--- a/game.js
+++ b/game.js
@@ -92,13 +92,15 @@ function moveBy(dx, dy){
   if (exploding) return;
   const nx = px + dx, ny = py + dy;
   if (isWall(nx, ny)) return;
+  const key = nx + "," + ny;
+  if (flagged.has(key)) return;
 
   const ox = px, oy = py;
   px = nx; py = ny;
   if (defuseMode){
     if (isMine(px, py)){
-      flagged.add(nx+","+ny);
-      revealed.add(nx+","+ny);
+      flagged.add(key);
+      revealed.add(key);
       px = ox; py = oy;
       floodReveal(px, py);
       autoRevealAround(px, py);


### PR DESCRIPTION
## Summary
- Prevent movement into any tile that has been flagged as a mine

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad608b63908329ba6a5f430db13b25