### PR TITLE
Avoid displaying zero when no nearby mines

### DIFF
--- a/game.js
+++ b/game.js
@@ -192,12 +192,15 @@ function render(){
     ctx.fillStyle = defuseMode ? '#ff0' : '#3572ff';
     ctx.fillRect(psx,psy,CELL-2,CELL-2);
     const playerMines=countAdjacentMines(px,py);
-    ctx.fillStyle=defuseMode ? '#000' : '#fff';
-    ctx.fillText(playerMines, psx+CELL/2, psy+CELL/2);
+    if(playerMines>0){
+      ctx.fillStyle=defuseMode ? '#000' : '#fff';
+      ctx.fillText(playerMines, psx+CELL/2, psy+CELL/2);
+    }
   }
 
   const currentMines = countAdjacentMines(px,py);
-  coordEl.textContent = `x: ${px}, y: ${py}, mines: ${currentMines}, flags: ${flagsLeft}, mode: ${defuseMode?'defuse':'walk'}`;
+  const mineInfo = currentMines>0 ? `, mines: ${currentMines}` : '';
+  coordEl.textContent = `x: ${px}, y: ${py}${mineInfo}, flags: ${flagsLeft}, mode: ${defuseMode?'defuse':'walk'}`;
 }
 render();
 


### PR DESCRIPTION
## Summary
- Skip drawing 0 in the player tile when no adjacent mines.
- Omit `mines: 0` from the coordinate display.

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aef38098788329b75e215167a35743