### PR TITLE
Add key-controlled auto reveal mode

### DIFF
--- a/game.js
+++ b/game.js
@@ -107,7 +107,6 @@ function moveBy(dx, dy){
         flagged.add(key);
         flagsLeft--;
       }
-      autoRevealAround(ox, oy);
     }
     defuseMode = false;
     px = ox; py = oy;
@@ -117,7 +116,7 @@ function moveBy(dx, dy){
 
   floodReveal(px, py);
   const steppedMine = isMine(px, py);
-  if (!steppedMine) autoRevealAround(px, py);
+  // autoRevealAround now triggered manually with key 2
   if (steppedMine){
     exploding = true;
     render();
@@ -236,6 +235,7 @@ window.addEventListener('keydown', e=>{
   else if (e.key==='+' || e.key==='=') zoom(1.1);
   else if (e.key==='-') zoom(0.9);
   else if (e.key===' ') { defuseMode = !defuseMode; render(); }
+  else if (e.key==='2') { autoRevealAround(px, py); render(); }
   else handled = false;
   if (handled) e.preventDefault();
 });


### PR DESCRIPTION
## Summary
- Remove automatic auto reveal around current tile
- Add keyboard key `2` to manually trigger auto revealing adjacent cells

## Testing
- `node --check game.js` *(fails: node: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b012e6fa4c83299250bf92b19faeb4