### PR TITLE
Add action buttons for flagging and revealing

### DIFF
--- a/game.js
+++ b/game.js
@@ -15,6 +15,7 @@ let exploding = false; // взрыв в процессе
 let defuseMode = false; // режим разминирования
 const flagged = new Set(); // отмеченные поля
 let flagsLeft = DEFAULT_FLAG_COUNT; // оставшиеся флажки
+let flagAction = null; // 'place' or 'remove'
 
 // посещённые области
 const revealed = new Set();
@@ -100,15 +101,17 @@ function moveBy(dx, dy){
   px = nx; py = ny;
   if (defuseMode){
     if(!revealed.has(key)){
-      if(flagged.has(key)){
-        flagged.delete(key);
-        flagsLeft++;
-      }else if(flagsLeft > 0){
+      const hasFlag = flagged.has(key);
+      if(flagAction === 'place' && !hasFlag && flagsLeft > 0){
         flagged.add(key);
         flagsLeft--;
+      }else if(flagAction === 'remove' && hasFlag){
+        flagged.delete(key);
+        flagsLeft++;
       }
     }
     defuseMode = false;
+    flagAction = null;
     px = ox; py = oy;
     render();
     return;
@@ -234,8 +237,10 @@ window.addEventListener('keydown', e=>{
   else if (e.key==='ArrowRight' || e.key==='d') moveBy(1,0);
   else if (e.key==='+' || e.key==='=') zoom(1.1);
   else if (e.key==='-') zoom(0.9);
-  else if (e.key===' ') { defuseMode = !defuseMode; render(); }
+  else if (e.key==='1') { defuseMode = true; flagAction = 'place'; render(); }
   else if (e.key==='2') { autoRevealAround(px, py); render(); }
+  else if (e.key==='3') { defuseMode = true; flagAction = 'remove'; render(); }
+  else if (e.key===' ') { defuseMode = !defuseMode; flagAction = 'place'; render(); }
   else handled = false;
   if (handled) e.preventDefault();
 });
@@ -244,3 +249,20 @@ canvas.addEventListener('wheel', e=>{
   e.preventDefault();
   zoom(e.deltaY<0?1.1:0.9);
 },{passive:false});
+
+document.getElementById('flagBtn').addEventListener('click', ()=>{
+  defuseMode = true;
+  flagAction = 'place';
+  render();
+});
+
+document.getElementById('revealBtn').addEventListener('click', ()=>{
+  autoRevealAround(px, py);
+  render();
+});
+
+document.getElementById('removeBtn').addEventListener('click', ()=>{
+  defuseMode = true;
+  flagAction = 'remove';
+  render();
+});

--- a/index.html
+++ b/index.html
@@ -21,12 +21,23 @@
   .left{grid-column:1;grid-row:2}
   .right{grid-column:3;grid-row:2}
   .down{grid-column:2;grid-row:3}
+  .actions{position:fixed;left:0;right:0;bottom:0;display:flex;justify-content:center;gap:20px;
+          padding:12px;pointer-events:none;}
+  .action-btn{pointer-events:auto;width:60px;height:60px;background:#fff;border:1px solid #bbb;
+              border-radius:12px;box-shadow:0 2px 6px rgba(0,0,0,.15);display:flex;
+              align-items:center;justify-content:center;font-size:28px;touch-action:none;}
+  .action-btn:active{transform:translateY(1px)}
 </style>
 </head>
 <body>
 <div id="wrap">
   <canvas id="game" width="640" height="480"></canvas>
   <div id="coords"></div>
+</div>
+<div id="actions" class="actions">
+  <button id="flagBtn" class="action-btn" title="Установить флаг">🚩</button>
+  <button id="revealBtn" class="action-btn" title="Открыть пустые">⬜️</button>
+  <button id="removeBtn" class="action-btn" title="Снять мину">💣</button>
 </div>
 <script type="module" src="game.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add bottom action bar with buttons for flag placement, revealing empty neighbors and removing mines
- handle button presses and number key shortcuts in game logic

## Testing
- `node --check game.js`
- `node --check constants.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0148f837c8329873edde42c8d196b